### PR TITLE
Feat: 로그인/회원가입 페이지 구현

### DIFF
--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -1,0 +1,92 @@
+import { ChangeEventHandler, FormEventHandler } from 'react';
+import { LockOutlined } from '@mui/icons-material';
+import { Avatar, Box, Container, TextField, Typography } from '@mui/material';
+import { LoadingButton } from '@mui/lab';
+
+interface LoginFormProps {
+  isLoading: boolean;
+  errorFieldNames: string[];
+  onSubmit: () => void;
+  onChange: (name: string, value: string) => void;
+}
+
+export const LoginForm = ({
+  errorFieldNames,
+  isLoading,
+  onSubmit,
+  onChange,
+}: LoginFormProps) => {
+  const isErrorField = (name: string) => errorFieldNames.includes(name);
+
+  const handleChange: ChangeEventHandler<HTMLFormElement> = (e) => {
+    const { name, value } = e.target;
+    onChange(name, value);
+  };
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+
+    onSubmit();
+  };
+
+  return (
+    <Container component="main" maxWidth="xs">
+      <Box
+        sx={{
+          marginTop: 8,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+        }}
+      >
+        <Avatar sx={{ m: 1, bgcolor: 'primary.main' }}>
+          <LockOutlined />
+        </Avatar>
+        <Typography component="h1" variant="h5">
+          로그인
+        </Typography>
+        <Box
+          component="form"
+          onChange={handleChange}
+          onSubmit={handleSubmit}
+          noValidate
+          sx={{ mt: 1 }}
+        >
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            id="email"
+            label="Email Address"
+            name="email"
+            autoComplete="email"
+            error={isErrorField('email')}
+            helperText={isErrorField('email') && '해당 값을 입력해 주세요.'}
+          />
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            name="password"
+            label="Password"
+            type="password"
+            id="password"
+            autoComplete="current-password"
+            error={isErrorField('password')}
+            helperText={isErrorField('password') && '해당 값을 입력해 주세요.'}
+          />
+
+          <LoadingButton
+            loading={isLoading}
+            type="submit"
+            fullWidth
+            variant="contained"
+            sx={{ mt: 3, mb: 2 }}
+          >
+            Sign In
+          </LoadingButton>
+        </Box>
+      </Box>
+    </Container>
+  );
+};

--- a/src/features/auth/components/RegisterForm.tsx
+++ b/src/features/auth/components/RegisterForm.tsx
@@ -1,0 +1,158 @@
+import React, { ChangeEventHandler, FormEventHandler } from 'react';
+import { LockOutlined } from '@mui/icons-material';
+import {
+  Container,
+  Box,
+  Avatar,
+  Typography,
+  TextField,
+  Button,
+  Divider,
+} from '@mui/material';
+import styled from '@emotion/styled';
+import { LoadingButton } from '@mui/lab';
+
+const ImageWrap = styled.div`
+  display: flex;
+  justify-content: center;
+  padding-bottom: 12px;
+`;
+
+interface RegisterFormProps {
+  profileImage: string;
+  errorFieldNames: string[];
+  isLoading: boolean;
+  onSubmit: () => void;
+  onChange: (name: string, value: string) => void;
+  onUpload: (file: File) => void;
+}
+
+export const RegisterForm = ({
+  isLoading,
+  profileImage,
+  errorFieldNames,
+  onSubmit,
+  onChange,
+  onUpload,
+}: RegisterFormProps) => {
+  const isErrorField = (name: string) => errorFieldNames.includes(name);
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+
+    onSubmit();
+  };
+
+  const handleChange: ChangeEventHandler<HTMLFormElement> = (e) => {
+    const { name, value } = e.target;
+
+    if (!name) {
+      return;
+    }
+
+    onChange(name, value);
+  };
+
+  const handleUpload: ChangeEventHandler<HTMLInputElement> = (e) => {
+    if (!e.target.files) {
+      return;
+    }
+
+    onUpload(e.target.files[0]);
+  };
+
+  return (
+    <Container component="main" maxWidth="xs">
+      <Box
+        sx={{
+          marginTop: 8,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+        }}
+      >
+        <Avatar sx={{ m: 1, bgcolor: 'primary.main' }}>
+          <LockOutlined />
+        </Avatar>
+        <Typography component="h1" variant="h5">
+          회원가입
+        </Typography>
+        <Box
+          component="form"
+          onSubmit={handleSubmit}
+          onChange={handleChange}
+          noValidate
+          sx={{ mt: 1 }}
+        >
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            id="email"
+            label="Email Address"
+            name="email"
+            autoComplete="email"
+            error={isErrorField('email')}
+            helperText={isErrorField('email') && '해당 값을 입력해 주세요.'}
+          />
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            name="password"
+            label="Password"
+            type="password"
+            id="password"
+            autoComplete="current-password"
+            error={isErrorField('password')}
+            helperText={isErrorField('password') && '해당 값을 입력해 주세요.'}
+          />
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            name="username"
+            label="Username"
+            type="text"
+            id="username"
+            error={isErrorField('username')}
+            helperText={isErrorField('username') && '해당 값을 입력해 주세요.'}
+          />
+
+          <Box mt={4}>
+            <ImageWrap>
+              <Avatar
+                sx={{
+                  width: 100,
+                  height: 100,
+                }}
+                src={profileImage}
+              />
+            </ImageWrap>
+            <Button variant="outlined" component="label" fullWidth>
+              Upload Profile
+              <input
+                accept="image/*"
+                type="file"
+                hidden
+                onChange={handleUpload}
+              />
+            </Button>
+          </Box>
+
+          <Divider sx={{ my: 4 }} />
+
+          <LoadingButton
+            loading={isLoading}
+            type="submit"
+            fullWidth
+            variant="contained"
+            sx={{ mt: 3, mb: 2 }}
+          >
+            Sign up
+          </LoadingButton>
+        </Box>
+      </Box>
+    </Container>
+  );
+};

--- a/src/features/auth/components/_stories/LoginForm.stories.tsx
+++ b/src/features/auth/components/_stories/LoginForm.stories.tsx
@@ -1,0 +1,36 @@
+import { ComponentProps } from 'react';
+import { ComponentStory, ComponentMeta, ArgTypes } from '@storybook/react';
+import { LoginForm } from '../LoginForm';
+
+type MyArgTypes = Partial<
+  Record<keyof ComponentProps<typeof LoginForm>, ArgTypes[string]>
+>;
+const argTypes: MyArgTypes = {};
+
+export default {
+  title: 'auth/LoginForm',
+  component: LoginForm,
+  argTypes,
+} as ComponentMeta<typeof LoginForm>;
+
+const Template: ComponentStory<typeof LoginForm> = ({ ...props }) => (
+  <LoginForm {...props} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  errorFieldNames: [],
+  isLoading: false,
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  ...Default.args,
+  isLoading: true,
+};
+
+export const Error = Template.bind({});
+Error.args = {
+  ...Default.args,
+  errorFieldNames: ['email', 'password'],
+};

--- a/src/features/auth/components/_stories/RegisterForm.stories.tsx
+++ b/src/features/auth/components/_stories/RegisterForm.stories.tsx
@@ -1,0 +1,38 @@
+import { ComponentProps } from 'react';
+import { ComponentStory, ComponentMeta, ArgTypes } from '@storybook/react';
+import { RegisterForm } from '../RegisterForm';
+
+type MyArgTypes = Partial<
+  Record<keyof ComponentProps<typeof RegisterForm>, ArgTypes[string]>
+>;
+const argTypes: MyArgTypes = {};
+
+export default {
+  title: 'auth/RegisterForm',
+  component: RegisterForm,
+  argTypes,
+} as ComponentMeta<typeof RegisterForm>;
+
+const Template: ComponentStory<typeof RegisterForm> = ({ ...props }) => (
+  <RegisterForm {...props} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  errorFieldNames: [],
+  isLoading: false,
+  profileImage:
+    'https://assets-kormelon-v2.s3.ap-northeast-2.amazonaws.com/winter.jpg',
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  ...Default.args,
+  isLoading: true,
+};
+
+export const Error = Template.bind({});
+Error.args = {
+  ...Default.args,
+  errorFieldNames: ['email', 'password', 'username'],
+};

--- a/src/features/auth/containers/AuthLoginContainer.tsx
+++ b/src/features/auth/containers/AuthLoginContainer.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import { useSelector } from 'react-redux';
+import { useRouter } from 'next/router';
+import { AuthLoginParams } from '@core/entities/auth.entity';
+import { useAppDispatch } from '@common/store';
+import { effAuthLogin, selAuthLoading } from '@shared/stores/auth';
+import { feedbackService } from '@common/components/Feedback';
+import { LoginForm } from '../components/LoginForm';
+
+export const AuthLoginContainer = () => {
+  const dispatch = useAppDispatch();
+  const isLoading = useSelector(selAuthLoading);
+  const router = useRouter();
+
+  const [form, setForm] = useState<AuthLoginParams>({
+    email: '',
+    password: '',
+  });
+  const [errorFieldNames, setErrorFieldNames] = useState<string[]>([]);
+
+  const handleSubmit = () => {
+    setErrorFieldNames([]);
+
+    let isErr = false;
+
+    Object.entries(form).forEach(([key, value]) => {
+      if (!value) {
+        isErr = true;
+        setErrorFieldNames((prev) => [...prev, key]);
+      }
+    });
+
+    if (isErr) {
+      return;
+    }
+
+    dispatch(effAuthLogin(form))
+      .unwrap()
+      .then(() => router.push('/'))
+      .catch((err) => {
+        feedbackService('error', err.response.data.message);
+      });
+  };
+
+  const handleChange = (name: string, value: string) => {
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  return (
+    <LoginForm
+      errorFieldNames={errorFieldNames}
+      isLoading={isLoading}
+      onSubmit={handleSubmit}
+      onChange={handleChange}
+    />
+  );
+};

--- a/src/features/auth/containers/AuthRegisterContainer.tsx
+++ b/src/features/auth/containers/AuthRegisterContainer.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import gravatar from 'gravatar';
+import { AuthRegisterParams } from '@core/entities/auth.entity';
+import { repo } from '@core/repo';
+import { useAppDispatch, useAppSelector } from '@common/store';
+import { effAuthRegister, selAuthLoading } from '@shared/stores/auth';
+import { feedbackService } from '@common/components/Feedback';
+import { RegisterForm } from '../components/RegisterForm';
+
+const defaultProfileImage = gravatar.url('default', {
+  s: '100',
+  r: 'pg',
+  d: 'retro',
+  protocol: 'http',
+});
+
+interface AuthRegisterContainerProps {
+  onSuccess: () => void;
+}
+
+export const AuthRegisterContainer = ({
+  onSuccess,
+}: AuthRegisterContainerProps) => {
+  const dispatch = useAppDispatch();
+
+  const isLoading = useAppSelector(selAuthLoading);
+
+  const [form, setForm] = useState<AuthRegisterParams>({
+    email: '',
+    password: '',
+    profileImage: defaultProfileImage,
+    username: '',
+  });
+  const [errorFieldNames, setErrorFieldNames] = useState<string[]>([]);
+
+  const handleSubmit = () => {
+    setErrorFieldNames([]);
+
+    let isErr = false;
+
+    Object.entries(form).forEach(([key, value]) => {
+      if (!value) {
+        isErr = true;
+        setErrorFieldNames((prev) => [...prev, key]);
+      }
+    });
+
+    if (isErr) {
+      return;
+    }
+
+    dispatch(effAuthRegister(form))
+      .unwrap()
+      .then(() => onSuccess())
+      .catch((err) => feedbackService('error', err.response.data.message));
+  };
+
+  const handleChange = (name: string, value: string) => {
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleUpload = async (file: File) => {
+    const profileImage = await repo.auth
+      .uploadProfileImage(file)
+      .then((res) => res.data.payload);
+
+    setForm((prev) => ({ ...prev, profileImage }));
+  };
+
+  return (
+    <RegisterForm
+      isLoading={isLoading}
+      errorFieldNames={errorFieldNames}
+      profileImage={form.profileImage}
+      onSubmit={handleSubmit}
+      onChange={handleChange}
+      onUpload={handleUpload}
+    />
+  );
+};

--- a/src/features/auth/routes/AuthPage.tsx
+++ b/src/features/auth/routes/AuthPage.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import styled from '@emotion/styled';
+import { Button } from '@mui/material';
+import { AuthLoginContainer } from '../containers/AuthLoginContainer';
+import { AuthRegisterContainer } from '../containers/AuthRegisterContainer';
+
+const Wrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 80vh;
+`;
+
+export const AuthPage = () => {
+  const [isLogin, setIsLogin] = useState(true);
+
+  const handleToggle = () => {
+    setIsLogin((prev) => !prev);
+  };
+
+  const handleSuccess = () => {
+    setIsLogin(true);
+  };
+
+  return (
+    <Wrap>
+      {isLogin ? (
+        <AuthLoginContainer />
+      ) : (
+        <AuthRegisterContainer onSuccess={handleSuccess} />
+      )}
+      <Button onClick={handleToggle}>{isLogin ? '회원가입' : '로그인'}</Button>
+    </Wrap>
+  );
+};

--- a/src/features/root/routes/RootPage.tsx
+++ b/src/features/root/routes/RootPage.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const RootPage = () => <div>RootPage</div>;
 
 export default RootPage;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,9 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ComponentProps } from 'react';
 import type { NextPage } from 'next';
+import { Provider } from 'react-redux';
 import type { AppProps } from 'next/app';
 
-import { Layout } from '@common/components/layouts';
+import { Layout } from '@shared/components/Layout';
+import store from '@common/store';
 
 export type NextPageWithLayout<P = Record<string, any>, IP = P> = NextPage<
   P,
@@ -18,8 +20,10 @@ type AppPropsWithLayout = AppProps & {
 
 export default function MyApp({ Component, pageProps }: AppPropsWithLayout) {
   return (
-    <Layout>
-      <Component {...pageProps} />
-    </Layout>
+    <Provider store={store}>
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
+    </Provider>
   );
 }

--- a/src/pages/auth.tsx
+++ b/src/pages/auth.tsx
@@ -1,0 +1,3 @@
+import { AuthPage } from '@features/auth/routes/AuthPage';
+
+export default AuthPage;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "paths": {
       "@core/*": ["src/core/*"],
       "@common/*": ["src/common/*"],
-      "@features/*": ["src/features/*"]
+      "@features/*": ["src/features/*"],
+      "@shared/*": ["src/shared/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "src"],


### PR DESCRIPTION
## Updates

- 로그인과 회원가입 페이지 구현
   - 실질적으로는 `/auth` 페이지 1개임.
 
## Notes

- form validate에 관한 헬퍼 함수 제작 고려 중 
- 스토리북 케이스 추가