### PR TITLE
Fix: 게시글 생성 시 태그 검색 값이 없을 때 모두 가져오는 이슈 대응

### DIFF
--- a/src/features/blog/containers/write/BlogPostTagSearchContainer.tsx
+++ b/src/features/blog/containers/write/BlogPostTagSearchContainer.tsx
@@ -33,6 +33,11 @@ export const BlogPostTagSearchContainer = ({
     useState<TagEntity[]>(outSelectedTags);
 
   const debounced = useDebouncedCallback(async (text: string) => {
+    if (!text) {
+      setSearchedTags([]);
+      return;
+    }
+
     const payload = await dispatch(effTagSearchLoad(text)).unwrap();
 
     const searchTags = payload.filter(


### PR DESCRIPTION
## Refs

resolve #62